### PR TITLE
Fix pivot table name for expenses transactions

### DIFF
--- a/app/Models/Expenses.php
+++ b/app/Models/Expenses.php
@@ -13,16 +13,20 @@ class Expenses extends Model
 ];
 
 
-    public function user() {
-    return $this->belongsTo(User::class);
-}
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
 
-public function transactions() {
-    return $this->belongsToMany(Transaction::class, 'type_transaction');
-}
+    public function transactions()
+    {
+        // Pivot table is `expense_type` linking expenses and transactions
+        return $this->belongsToMany(Transaction::class, 'expense_type');
+    }
 
-public function budgets() {
-    return $this->hasMany(Budget::class);
-}
+    public function budgets()
+    {
+        return $this->hasMany(Budget::class);
+    }
 
 }

--- a/database/migrations/2025_07_03_191915_create_expense_type_table.php
+++ b/database/migrations/2025_07_03_191915_create_expense_type_table.php
@@ -10,13 +10,13 @@ return new class extends Migration
      * Run the migrations.
      */
     public function up()
-{
-    Schema::create('expense_type', function (Blueprint $table) {
-        $table->id();
-        $table->foreignId('transaction_id')->constrained()->onDelete('cascade');
-        $table->foreignId('expenses_id')->constrained()->onDelete('cascade');
-    });
-}
+    {
+        Schema::create('expense_type', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('transaction_id')->constrained()->onDelete('cascade');
+            $table->foreignId('expenses_id')->constrained()->onDelete('cascade');
+        });
+    }
 
 
     /**
@@ -24,6 +24,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('type_transaction');
+        Schema::dropIfExists('expense_type');
     }
 };


### PR DESCRIPTION
## Summary
- align Expenses-Transaction pivot table name across model and migration
- ensure migration rollback drops the correct pivot table

## Testing
- `composer test` *(fails: vendor/autoload.php not found)*

------
