### PR TITLE
Add API logout endpoint

### DIFF
--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Http\JsonResponse;
+
+class AuthController extends Controller
+{
+    /**
+     * Log out the authenticated user and invalidate the session.
+     */
+    public function logout(Request $request): JsonResponse
+    {
+        Auth::guard('web')->logout();
+
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+
+        return response()->noContent();
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,6 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Api\AuthController;
+
+Route::middleware('auth:sanctum')->post('/logout', [AuthController::class, 'logout']);

--- a/tests/Feature/Api/AuthTest.php
+++ b/tests/Feature/Api/AuthTest.php
@@ -1,0 +1,15 @@
+<?php
+
+use App\Models\User;
+use Laravel\Sanctum\Sanctum;
+
+it('allows an authenticated user to log out via the API', function () {
+    $user = User::factory()->create();
+
+    Sanctum::actingAs($user);
+
+    $response = $this->postJson('/api/logout');
+
+    $response->assertNoContent();
+    $this->assertGuest();
+});


### PR DESCRIPTION
## Summary
- add Auth API controller with logout method
- expose POST /api/logout route secured by auth middleware
- cover API logout flow with feature test

## Testing
- `php artisan test` *(fails: require vendor/autoload.php: No such file or directory)*

------
