### PR TITLE
Restrict account and transaction listings to current user

### DIFF
--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Models\Account;
+use Illuminate\Support\Facades\Auth;
 
 
 class AccountController extends Controller
@@ -13,7 +14,7 @@ class AccountController extends Controller
      */
     public function index()
     {
-        $accounts = Account::with('user')->get(); // eager load user if needed
+        $accounts = Account::where('user_id', auth()->id())->get();
         return view('accounts.index', compact('accounts'));
     }
 

--- a/app/Http/Controllers/TransactionController.php
+++ b/app/Http/Controllers/TransactionController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Models\Transaction;
+use Illuminate\Support\Facades\Auth;
 
 
 class TransactionController extends Controller
@@ -13,7 +14,9 @@ class TransactionController extends Controller
      */
     public function index()
     {
-        $transactions = Transaction::with('account', 'expenses')->latest()->get();
+        $transactions = Transaction::whereHas('account', function ($query) {
+            $query->where('user_id', auth()->id());
+        })->with('account', 'expenses')->latest()->get();
 
         return view('transactions.index', compact('transactions'));
     }


### PR DESCRIPTION
## Summary
- Limit account listing to authenticated user ID
- Scope transaction listing to accounts belonging to authenticated user

## Testing
- `composer test` *(fails: vendor autoload missing)*
- `composer install` *(fails: GitHub 403 during package download)*

------
https://chatgpt.com/codex/tasks/task_e_68abb0806d30832f8797a1c2c9ed11eb