### PR TITLE
Rename budgets migration and update expense references

### DIFF
--- a/app/Models/Budget.php
+++ b/app/Models/Budget.php
@@ -6,25 +6,20 @@ use Illuminate\Database\Eloquent\Model;
 
 class Budget extends Model
 {
-
     protected $fillable = [
-    'user_id',
-    'category_id',
-    'amount',
-    'period',
-];
+        'user_id',
+        'expense_id',
+        'amount',
+        'period',
+    ];
 
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
 
-    public function user() {
-    return $this->belongsTo(User::class);
-}
-
-
-
-
-
-public function Expenses() {
-    return $this->belongsTo(Expenses::class);
-}
-
+    public function expense()
+    {
+        return $this->belongsTo(Expenses::class, 'expense_id');
+    }
 }

--- a/app/Models/Expenses.php
+++ b/app/Models/Expenses.php
@@ -26,7 +26,7 @@ class Expenses extends Model
 
     public function budgets()
     {
-        return $this->hasMany(Budget::class);
+        return $this->hasMany(Budget::class, 'expense_id');
     }
 
 }

--- a/database/migrations/2025_07_03_191417_create_budgets_table.php
+++ b/database/migrations/2025_07_03_191417_create_budgets_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
 {
     Schema::create('budgets', function (Blueprint $table) {
         $table->id();
-        $table->foreignId('expenses_id')->constrained()->onDelete('cascade');
+        $table->foreignId('expense_id')->constrained()->onDelete('cascade');
         $table->foreignId('user_id')->constrained()->onDelete('cascade');
         $table->decimal('amount', 12, 2);
         $table->enum('period', ['monthly', 'quarterly']);

--- a/database/seeders/BudgetSeeder.php
+++ b/database/seeders/BudgetSeeder.php
@@ -15,27 +15,21 @@ class BudgetSeeder extends Seeder
      */
     public function run(): void
     {
-
-        {
         $user = User::first();
         $food = Expenses::where('name', 'Food')->first();
         $transport = Expenses::where('name', 'Transport')->first();
 
         $user->budgets()->createMany([
             [
-                'expenses_id' => $food->id,
+                'expense_id' => $food->id,
                 'amount' => 400.00,
                 'period' => 'monthly',
             ],
             [
-                'expenses_id' => $transport->id,
+                'expense_id' => $transport->id,
                 'amount' => 150.00,
                 'period' => 'monthly',
             ],
         ]);
-
-        
     }
-}
-
 }

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -34,7 +34,7 @@
                 <div class="budget-item">
                     <div class="budget-card">
                         <div class="budget-name">
-                            {{ $budget->expenses->name ?? 'No category' }}
+                            {{ $budget->expense->name ?? 'No category' }}
                         </div>
                         <div class="budget-amount">
                             ${{ number_format($budget->amount, 2) }}


### PR DESCRIPTION
## Summary
- fix budgets migration filename and change `expenses_id` column to `expense_id`
- rename Budget model relationship to `expense()` and align seeders and views
- specify `expense_id` foreign key in Expenses mo