### PR TITLE
Switch home page to full-width marketing layout

### DIFF
--- a/app/View/Components/MarketingLayout.php
+++ b/app/View/Components/MarketingLayout.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\View\Components;
+
+use Illuminate\View\Component;
+use Illuminate\View\View;
+
+class MarketingLayout extends Component
+{
+    /**
+     * Get the view / contents that represents the component.
+     */
+    public function render(): View
+    {
+        return view('layouts.marketing');
+    }
+}

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -1,4 +1,4 @@
-<x-guest-layout>
+<x-marketing-layout>
   {{-- HERO SECTION --}}
   <section class="relative min-h-[60vh] flex items-center">
     {{-- Background gradient --}}
@@ -174,4 +174,4 @@
       </div>
     </div>
   </section>
-</x-guest-layout>
+</x-marketing-layout>

--- a/resources/views/layouts/marketing.blade.php
+++ b/resources/views/layouts/marketing.blade.php
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="csrf-token" content="{{ csrf_token() }}">
+
+        <title>{{ config('app.name', 'Laravel') }}</title>
+
+        <!-- Fonts -->
+        <link rel="preconnect" href="https://fonts.bunny.net">
+        <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
+
+        <!-- Scripts -->
+        @if (file_exists(public_path('build/manifest.json')))
+            @vite(['resources/css/app.css', 'resources/js/app.js'])
+        @endif
+    </head>
+    <body class="font-sans text-gray-900 antialiased">
+        <div class="min-h-screen flex flex-col bg-gray-100">
+            <header class="flex justify-between items-center p-6">
+                <a href="/">
+                    <x-application-logo class="w-20 h-20 fill-current text-gray-500" />
+                </a>
+                <nav class="flex items-center space-x-4">
+                    @auth
+                        <a href="{{ route('dashboard') }}" class="text-sm text-gray-700">
+                            {{ __('Dashboard') }}
+                        </a>
+                    @else
+                        <a href="{{ route('login') }}" class="text-sm text-gray-700">
+                            {{ __('Log in') }}
+                        </a>
+                        @if (Route::has('register'))
+                            <a href="{{ route('register') }}" class="text-sm text-gray-700">
+                                {{ __('Register') }}
+                            </a>
+                        @endif
+                    @endauth
+                </nav>
+            </header>
+
+            <main class="flex-grow">
+                {{ $slot }}
+            </main>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
## Summary
- add marketing layout component without mobile width limit
- use marketing layout on home page for desktop-friendly design

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bcea84ee20832f810c70c2414ffbe8