### PR TITLE
Add dashboard data endpoints and charts

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Transaction;
+use App\Models\Expenses;
+use Illuminate\Support\Facades\DB;
+
+class DashboardController extends Controller
+{
+    /**
+     * Show the dashboard view.
+     */
+    public function index()
+    {
+        $user = auth()->user();
+        $accounts = $user->accounts;
+        $budgets = $user->budgets()->with('expense')->get();
+
+        return view('dashboard', compact('user', 'accounts', 'budgets'));
+    }
+
+    /**
+     * Return aggregated monthly transaction totals for the authenticated user.
+     */
+    public function monthlyTotals()
+    {
+        $userId = auth()->id();
+
+        $totals = Transaction::select(
+                DB::raw("DATE_FORMAT(date, '%Y-%m') as month"),
+                DB::raw('SUM(amount) as total')
+            )
+            ->whereHas('account', function ($q) use ($userId) {
+                $q->where('user_id', $userId);
+            })
+            ->groupBy('month')
+            ->orderBy('month')
+            ->get();
+
+        return response()->json($totals);
+    }
+
+    /**
+     * Return aggregated totals grouped by expense category for the authenticated user.
+     */
+    public function categoryTotals()
+    {
+        $userId = auth()->id();
+
+        $totals = Expenses::select(
+                'expenses.name as category',
+                DB::raw('SUM(transactions.amount) as total')
+            )
+            ->join('expense_type', 'expenses.id', '=', 'expense_type.expenses_id')
+            ->join('transactions', 'expense_type.transaction_id', '=', 'transactions.id')
+            ->join('accounts', 'transactions.account_id', '=', 'accounts.id')
+            ->where('expenses.user_id', $userId)
+            ->where('accounts.user_id', $userId)
+            ->groupBy('expenses.name')
+            ->get();
+
+        return response()->json($totals);
+    }
+}
+

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1,0 +1,16 @@
+# Dashboard
+
+The dashboard visualizes spending trends using [Chart.js](https://www.chartjs.org/).
+
+## API Endpoints
+
+- `GET /api/dashboard/monthly-totals` – aggregated totals by month for the authenticated user.
+- `GET /api/dashboard/category-totals` – aggregated totals grouped by expense category.
+
+## Example Charts
+
+The monthly totals are displayed as a bar chart and category totals as a doughnut chart.
+
+![Monthly totals chart](https://via.placeholder.com/600x300?text=Monthly+Totals+Chart)
+
+![Category totals chart](https://via.placeholder.com/600x300?text=Category+Totals+Chart)

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -47,6 +47,55 @@
                     @endforeach
                 </section>
             </div>
+
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mt-6">
+                <section class="bg-white shadow-sm sm:rounded-lg p-6">
+                    <h3 class="text-lg font-semibold mb-4 text-gray-800">Monthly Totals</h3>
+                    <canvas id="monthlyTotalsChart"></canvas>
+                </section>
+                <section class="bg-white shadow-sm sm:rounded-lg p-6">
+                    <h3 class="text-lg font-semibold mb-4 text-gray-800">Category Totals</h3>
+                    <canvas id="categoryTotalsChart"></canvas>
+                </section>
+            </div>
         </div>
     </div>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            fetch('/api/dashboard/monthly-totals')
+                .then(r => r.json())
+                .then(data => {
+                    const labels = data.map(item => item.month);
+                    const totals = data.map(item => item.total);
+                    new Chart(document.getElementById('monthlyTotalsChart'), {
+                        type: 'bar',
+                        data: {
+                            labels,
+                            datasets: [{
+                                label: 'Total',
+                                data: totals,
+                                backgroundColor: 'rgba(59, 130, 246, 0.5)',
+                            }]
+                        },
+                    });
+                });
+
+            fetch('/api/dashboard/category-totals')
+                .then(r => r.json())
+                .then(data => {
+                    const labels = data.map(item => item.category);
+                    const totals = data.map(item => item.total);
+                    new Chart(document.getElementById('categoryTotalsChart'), {
+                        type: 'doughnut',
+                        data: {
+                            labels,
+                            datasets: [{
+                                data: totals,
+                            }]
+                        },
+                    });
+                });
+        });
+    </script>
 </x-app-layout>

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,8 +3,12 @@
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Api\AuthController;
 use App\Http\Controllers\Api\PlaidController;
+use App\Http\Controllers\DashboardController;
 
 Route::middleware('auth:sanctum')->post('/logout', [AuthController::class, 'logout']);
 
 Route::get('/plaid/link-token', [PlaidController::class, 'linkToken']);
 Route::post('/plaid/webhook', [PlaidController::class, 'webhook']);
+
+Route::get('/dashboard/monthly-totals', [DashboardController::class, 'monthlyTotals']);
+Route::get('/dashboard/category-totals', [DashboardController::class, 'categoryTotals']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\AccountController;
 use App\Http\Controllers\TransactionController;
+use App\Http\Controllers\DashboardController;
 use Illuminate\Support\Facades\Route;
 
 // Public home page
@@ -12,18 +13,11 @@ Route::view('/', 'home')->name('home');
 require __DIR__.'/auth.php';
 
 // Auth-only pages
-Route::middleware(['auth'])->group(function () {
-    Route::get('/dashboard', function () {
-        $user = auth()->user();
-        $accounts = $user->accounts;
-        $budgets = $user->budgets()->with('expense')->get();
-        return view('dashboard', compact('user', 'accounts', 'budgets'));
-    })
-        ->middleware('verified')
-        ->name('dashboard');
+Route::middleware(['auth', 'verified'])->group(function () {
+    Route::get('/dashboard', [DashboardController::class, 'index'])->name('dashboard');
 
-      Route::resource('accounts', AccountController::class);
-      Route::resource('transactions', TransactionController::class);
+    Route::resource('accounts', AccountController::class);
+    Route::resource('transactions', TransactionController::class);
 
     // (Optional) Breeze profile
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');


### PR DESCRIPTION
## Summary
- add DashboardController with endpoints for monthly and category totals
- expose new API routes and controller-driven dashboard route
- render Chart.js visualizations and document sample dashboard

## Testing
- `composer install`
- `./vendor/bin/pest` *(fails: No application encryption key has been specified)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bd1b0b932c832f8db43d41f630bf07