### PR TITLE
Ensure account balances reflect transactions and add recalculation command

### DIFF
--- a/app/Console/Commands/RecalculateAccountBalance.php
+++ b/app/Console/Commands/RecalculateAccountBalance.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Account;
+use Illuminate\Console\Command;
+
+class RecalculateAccountBalance extends Command
+{
+    protected $signature = 'account:recalc';
+
+    protected $description = 'Recalculate balances for all accounts based on their transactions';
+
+    public function handle(): int
+    {
+        Account::all()->each->updateBalance();
+
+        $this->info('Account balances recalculated successfully.');
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Models/Account.php
+++ b/app/Models/Account.php
@@ -10,17 +10,26 @@ class Account extends Model
     use HasFactory;
 
     protected $fillable = [
-    'user_id',
-    'name',
-    'type',
-    'balance',
-];
-    public function user() {
-    return $this->belongsTo(User::class);
-}
+        'user_id',
+        'name',
+        'type',
+        'balance',
+    ];
 
-public function transactions() {
-    return $this->hasMany(Transaction::class);
-}
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
 
+    public function transactions()
+    {
+        return $this->hasMany(Transaction::class);
+    }
+
+    public function updateBalance(): void
+    {
+        $this->update([
+            'balance' => $this->transactions()->sum('amount'),
+        ]);
+    }
 }

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -8,21 +8,32 @@ class Transaction extends Model
 {
 
     protected $fillable = [
-    'account_id',
-    'type',
-    'description',
-    'amount',
-    'date',
-];
+        'account_id',
+        'type',
+        'description',
+        'amount',
+        'date',
+    ];
+
+    protected static function booted(): void
+    {
+        $update = fn (Transaction $transaction) => $transaction->account?->updateBalance();
+
+        static::created($update);
+        static::updated($update);
+        static::deleted($update);
+    }
 
 
 
-    public function account() {
-    return $this->belongsTo(Account::class);
-}
+    public function account()
+    {
+        return $this->belongsTo(Account::class);
+    }
 
-public function expenses() {
-    return $this->belongsToMany(Expenses::class, 'expense_type');
-}
+    public function expenses()
+    {
+        return $this->belongsToMany(Expenses::class, 'expense_type');
+    }
 
 }

--- a/tests/Feature/AccountBalanceTest.php
+++ b/tests/Feature/AccountBalanceTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use App\Models\Account;
+use App\Models\Transaction;
+use App\Models\User;
+use function Pest\Laravel\artisan;
+use Illuminate\Support\Carbon;
+
+it('keeps account balance in sync via transaction events', function () {
+    $user = User::factory()->create();
+    $account = Account::create([
+        'user_id' => $user->id,
+        'name' => 'Checking',
+        'type' => 'checking',
+        'balance' => 0,
+    ]);
+
+    $transaction = Transaction::create([
+        'account_id' => $account->id,
+        'type' => 'income',
+        'description' => 'Deposit',
+        'amount' => 100,
+        'date' => Carbon::now()->toDateString(),
+    ]);
+
+    $account->refresh();
+    expect((float) $account->balance)->toBe(100.0);
+
+    $transaction->update(['amount' => 50]);
+    $account->refresh();
+    expect((float) $account->balance)->toBe(50.0);
+
+    $transaction->delete();
+    $account->refresh();
+    expect((float) $account->balance)->toBe(0.0);
+});
+
+it('recalculates balances using the artisan command', function () {
+    $user = User::factory()->create();
+    $account = Account::create([
+        'user_id' => $user->id,
+        'name' => 'Cash',
+        'type' => 'cash',
+        'balance' => 0,
+    ]);
+
+    Transaction::create([
+        'account_id' => $account->id,
+        'type' => 'income',
+        'description' => 'Deposit',
+        'amount' => 100,
+        'date' => Carbon::now()->toDateString(),
+    ]);
+
+    Transaction::create([
+        'account_id' => $account->id,
+        'type' => 'expense',
+        'description' => 'Withdrawal',
+        'amount' => -40,
+        'date' => Carbon::now()->toDateString(),
+    ]);
+
+    $account->update(['balance' => 999]);
+
+    artisan('account:recalc')->assertExitCode(0);
+
+    $account->refresh();
+    expect((float) $account->balance)->toBe(60.0);
+});
+


### PR DESCRIPTION
## Summary
- Recalculate an account's balance by summing its transactions
- Sync account balances on transaction create, update, or delete events
- Add `account:recalc` artisan command and tests for balance recalculation

## Testing
- `php artisan test`
