### PR TITLE
Add filterable dashboard aggregates with real-time updates

### DIFF
--- a/app/Events/TransactionChanged.php
+++ b/app/Events/TransactionChanged.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Transaction;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class TransactionChanged implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public string $action;
+    public Transaction $transaction;
+
+    public function __construct(Transaction $transaction, string $action)
+    {
+        $this->transaction = $transaction;
+        $this->action = $action;
+    }
+
+    public function broadcastOn(): Channel
+    {
+        return new Channel('transactions');
+    }
+
+    public function broadcastWith(): array
+    {
+        return [
+            'id' => $this->transaction->id,
+            'action' => $this->action,
+        ];
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'TransactionChanged';
+    }
+}

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Transaction;
 use App\Models\Expenses;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 
 class DashboardController extends Controller
@@ -16,25 +17,45 @@ class DashboardController extends Controller
         $user = auth()->user();
         $accounts = $user->accounts;
         $budgets = $user->budgets()->with('expense')->get();
+        $categories = $user->expenses;
 
-        return view('dashboard', compact('user', 'accounts', 'budgets'));
+        return view('dashboard', compact('user', 'accounts', 'budgets', 'categories'));
     }
 
     /**
      * Return aggregated monthly transaction totals for the authenticated user.
      */
-    public function monthlyTotals()
+    public function monthlyTotals(Request $request)
     {
         $userId = auth()->id();
 
-        $totals = Transaction::select(
+        $query = Transaction::select(
                 DB::raw("DATE_FORMAT(date, '%Y-%m') as month"),
                 DB::raw('SUM(amount) as total')
             )
             ->whereHas('account', function ($q) use ($userId) {
                 $q->where('user_id', $userId);
-            })
-            ->groupBy('month')
+            });
+
+        if ($request->filled('start')) {
+            $query->whereDate('date', '>=', $request->input('start'));
+        }
+
+        if ($request->filled('end')) {
+            $query->whereDate('date', '<=', $request->input('end'));
+        }
+
+        if ($request->filled('account')) {
+            $query->where('account_id', $request->input('account'));
+        }
+
+        if ($request->filled('category')) {
+            $query->whereHas('expenses', function ($q) use ($request) {
+                $q->where('expenses.id', $request->input('category'));
+            });
+        }
+
+        $totals = $query->groupBy('month')
             ->orderBy('month')
             ->get();
 
@@ -44,11 +65,11 @@ class DashboardController extends Controller
     /**
      * Return aggregated totals grouped by expense category for the authenticated user.
      */
-    public function categoryTotals()
+    public function categoryTotals(Request $request)
     {
         $userId = auth()->id();
 
-        $totals = Expenses::select(
+        $query = Expenses::select(
                 'expenses.name as category',
                 DB::raw('SUM(transactions.amount) as total')
             )
@@ -56,8 +77,105 @@ class DashboardController extends Controller
             ->join('transactions', 'expense_type.transaction_id', '=', 'transactions.id')
             ->join('accounts', 'transactions.account_id', '=', 'accounts.id')
             ->where('expenses.user_id', $userId)
-            ->where('accounts.user_id', $userId)
-            ->groupBy('expenses.name')
+            ->where('accounts.user_id', $userId);
+
+        if ($request->filled('start')) {
+            $query->whereDate('transactions.date', '>=', $request->input('start'));
+        }
+
+        if ($request->filled('end')) {
+            $query->whereDate('transactions.date', '<=', $request->input('end'));
+        }
+
+        if ($request->filled('account')) {
+            $query->where('accounts.id', $request->input('account'));
+        }
+
+        if ($request->filled('category')) {
+            $query->where('expenses.id', $request->input('category'));
+        }
+
+        $totals = $query->groupBy('expenses.name')
+            ->get();
+
+        return response()->json($totals);
+    }
+
+    /**
+     * Return aggregated weekly transaction totals for the authenticated user.
+     */
+    public function weeklyTotals(Request $request)
+    {
+        $userId = auth()->id();
+
+        $query = Transaction::select(
+                DB::raw("DATE_FORMAT(date, '%x-%v') as week"),
+                DB::raw('SUM(amount) as total')
+            )
+            ->whereHas('account', function ($q) use ($userId) {
+                $q->where('user_id', $userId);
+            });
+
+        if ($request->filled('start')) {
+            $query->whereDate('date', '>=', $request->input('start'));
+        }
+
+        if ($request->filled('end')) {
+            $query->whereDate('date', '<=', $request->input('end'));
+        }
+
+        if ($request->filled('account')) {
+            $query->where('account_id', $request->input('account'));
+        }
+
+        if ($request->filled('category')) {
+            $query->whereHas('expenses', function ($q) use ($request) {
+                $q->where('expenses.id', $request->input('category'));
+            });
+        }
+
+        $totals = $query->groupBy('week')
+            ->orderBy('week')
+            ->get();
+
+        return response()->json($totals);
+    }
+
+    /**
+     * Return aggregated daily transaction totals for the authenticated user.
+     */
+    public function dailyTotals(Request $request)
+    {
+        $userId = auth()->id();
+
+        $query = Transaction::select(
+                DB::raw('DATE(date) as day'),
+                DB::raw('SUM(amount) as total')
+            )
+            ->whereHas('account', function ($q) use ($userId) {
+                $q->where('user_id', $userId);
+            });
+
+        if ($request->filled('start')) {
+            $query->whereDate('date', '>=', $request->input('start'));
+        }
+
+        if ($request->filled('end')) {
+            $query->whereDate('date', '<=', $request->input('end'));
+        }
+
+        if ($request->filled('account')) {
+            $query->where('account_id', $request->input('account'));
+        }
+
+        if ($request->filled('category')) {
+            $query->whereHas('expenses', function ($q) use ($request) {
+                $q->where('expenses.id', $request->input('category'));
+            });
+        }
+
+        $totals = $query->groupBy('day')
+            ->orderBy('day')
             ->get();
 
         return response()->json($totals);

--- a/app/Http/Controllers/TransactionController.php
+++ b/app/Http/Controllers/TransactionController.php
@@ -6,6 +6,7 @@ use App\Http\Requests\StoreTransactionRequest;
 use App\Models\Account;
 use App\Models\Transaction;
 use Illuminate\Support\Facades\Auth;
+use App\Events\TransactionChanged;
 
 
 class TransactionController extends Controller
@@ -37,7 +38,9 @@ class TransactionController extends Controller
      */
     public function store(StoreTransactionRequest $request)
     {
-        Transaction::create($request->validated());
+        $transaction = Transaction::create($request->validated());
+
+        broadcast(new TransactionChanged($transaction, 'created'))->toOthers();
 
         return redirect()->route('transactions.index');
     }
@@ -67,6 +70,8 @@ class TransactionController extends Controller
     {
         $transaction->update($request->validated());
 
+        broadcast(new TransactionChanged($transaction, 'updated'))->toOthers();
+
         return redirect()->route('transactions.index');
     }
 
@@ -76,6 +81,8 @@ class TransactionController extends Controller
     public function destroy(Transaction $transaction)
     {
         $transaction->delete();
+
+        broadcast(new TransactionChanged($transaction, 'deleted'))->toOthers();
 
         return redirect()->route('transactions.index');
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -11,4 +11,6 @@ Route::get('/plaid/link-token', [PlaidController::class, 'linkToken']);
 Route::post('/plaid/webhook', [PlaidController::class, 'webhook']);
 
 Route::get('/dashboard/monthly-totals', [DashboardController::class, 'monthlyTotals']);
+Route::get('/dashboard/weekly-totals', [DashboardController::class, 'weeklyTotals']);
+Route::get('/dashboard/daily-totals', [DashboardController::class, 'dailyTotals']);
 Route::get('/dashboard/category-totals', [DashboardController::class, 'categoryTotals']);


### PR DESCRIPTION
## Summary
- add filtering and weekly/daily aggregations for dashboard metrics
- broadcast transaction create/update/delete events
- enhance dashboard with filter controls and live chart updates via Laravel Echo

## Testing
- `php artisan test` (fails: No application encryption key has been specified)


------
https://chatgpt.com/codex/tasks/task_e_68bf1659acf4832fbf7576cca89c530f