### PR TITLE
Restrict transaction types to predefined list

### DIFF
--- a/app/Http/Requests/StoreTransactionRequest.php
+++ b/app/Http/Requests/StoreTransactionRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class StoreTransactionRequest extends FormRequest
 {
@@ -23,7 +24,7 @@ class StoreTransactionRequest extends FormRequest
     {
         return [
             'account_id' => ['required', 'exists:accounts,id'],
-            'type' => ['required', 'string', 'max:255'],
+            'type' => ['required', 'string', Rule::in(['income', 'expense', 'transfer'])],
             'description' => ['nullable', 'string'],
             'amount' => ['required', 'numeric'],
             'date' => ['required', 'date'],

--- a/resources/views/transactions/create.blade.php
+++ b/resources/views/transactions/create.blade.php
@@ -6,6 +6,7 @@
   </x-slot>
   <div class="py-6">
     <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+      @php($types = ['income', 'expense', 'transfer'])
       <form method="POST" action="{{ route('transactions.store') }}" class="space-y-4">
         @csrf
         <div>
@@ -18,7 +19,11 @@
         </div>
         <div>
           <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Type</label>
-          <input type="text" name="type" class="mt-1 block w-full" />
+          <select name="type" class="mt-1 block w-full">
+            @foreach($types as $type)
+              <option value="{{ $type }}" @selected(old('type') === $type)>{{ ucfirst($type) }}</option>
+            @endforeach
+          </select>
         </div>
         <div>
           <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Description</label>

--- a/resources/views/transactions/edit.blade.php
+++ b/resources/views/transactions/edit.blade.php
@@ -6,6 +6,7 @@
   </x-slot>
   <div class="py-6">
     <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+      @php($types = ['income', 'expense', 'transfer'])
       <form method="POST" action="{{ route('transactions.update', $transaction) }}" class="space-y-4">
         @csrf
         @method('PUT')
@@ -19,7 +20,11 @@
         </div>
         <div>
           <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Type</label>
-          <input type="text" name="type" value="{{ old('type', $transaction->type) }}" class="mt-1 block w-full" />
+          <select name="type" class="mt-1 block w-full">
+            @foreach($types as $type)
+              <option value="{{ $type }}" @selected(old('type', $transaction->type) === $type)>{{ ucfirst($type) }}</option>
+            @endforeach
+          </select>
         </div>
         <div>
           <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Description</label>


### PR DESCRIPTION
## Summary
- replace free-text transaction type inputs with select menus for income, expense, or transfer
- validate transactions against the same set of allowed types

## Testing
- `composer test` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bf133792cc832f8b021f90fa9828f1