### PR TITLE
feat: add chart loaders

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,3 +1,16 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.loader {
+  border: 4px solid rgba(59, 130, 246, 0.2);
+  border-top-color: rgba(59, 130, 246, 1);
+  border-radius: 50%;
+  width: 2.5rem;
+  height: 2.5rem;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -51,11 +51,21 @@
             <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mt-6">
                 <section class="bg-white shadow-sm sm:rounded-lg p-6">
                     <h3 class="text-lg font-semibold mb-4 text-gray-800">Monthly Totals</h3>
-                    <canvas id="monthlyTotalsChart"></canvas>
+                    <div id="monthlyChartWrapper" x-data="{ loading: true }" class="relative">
+                        <div x-show="loading" class="absolute inset-0 flex items-center justify-center bg-white/70">
+                            <div class="loader"></div>
+                        </div>
+                        <canvas id="monthlyTotalsChart"></canvas>
+                    </div>
                 </section>
                 <section class="bg-white shadow-sm sm:rounded-lg p-6">
                     <h3 class="text-lg font-semibold mb-4 text-gray-800">Category Totals</h3>
-                    <canvas id="categoryTotalsChart"></canvas>
+                    <div id="categoryChartWrapper" x-data="{ loading: true }" class="relative">
+                        <div x-show="loading" class="absolute inset-0 flex items-center justify-center bg-white/70">
+                            <div class="loader"></div>
+                        </div>
+                        <canvas id="categoryTotalsChart"></canvas>
+                    </div>
                 </section>
             </div>
         </div>
@@ -79,6 +89,7 @@
                             }]
                         },
                     });
+                    document.getElementById('monthlyChartWrapper').__x.$data.loading = false;
                 });
 
             fetch('/api/dashboard/category-totals')
@@ -95,6 +106,7 @@
                             }]
                         },
                     });
+                    document.getElementById('categoryChartWrapper').__x.$data.loading = false;
                 });
         });
     </script>

--- a/resources/views/transactions/index.blade.php
+++ b/resources/views/transactions/index.blade.php
@@ -9,9 +9,12 @@
     <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
       <div class="bg-white dark:bg-gray-800 shadow-sm sm:rounded-lg">
         <div class="p-6 space-y-6">
-          <div>
-            <canvas id="transactionsChart" class="w-full h-64"></canvas>
-          </div>
+            <div id="transactionsChartWrapper" x-data="{ loading: true }" class="relative">
+              <div x-show="loading" class="absolute inset-0 flex items-center justify-center bg-white/70">
+                <div class="loader"></div>
+              </div>
+              <canvas id="transactionsChart" class="w-full h-64"></canvas>
+            </div>
 
           <!-- Bulk action toolbar -->
           <div x-show="selected.length" class="flex items-center gap-3 p-3 rounded-md bg-gray-100 dark:bg-gray-700">
@@ -111,24 +114,25 @@
 
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script>
-    const txCtx = document.getElementById('transactionsChart').getContext('2d');
-    const txChart = new Chart(txCtx, {
-      type: 'bar',
-      data: {
-        labels: @json($transactions->pluck('date')->map(fn($d) => optional($d)->format('Y-m-d'))),
-        datasets: [{
-          label: 'Amount',
-          data: @json($transactions->pluck('amount')),
-          backgroundColor: '#4f46e5'
-        }]
-      },
-      options: {
-        plugins: { legend: { display: false } },
-        scales: {
-          y: { beginAtZero: true }
-        }
+  const txCtx = document.getElementById('transactionsChart').getContext('2d');
+  const txChart = new Chart(txCtx, {
+    type: 'bar',
+    data: {
+      labels: @json($transactions->pluck('date')->map(fn($d) => optional($d)->format('Y-m-d'))),
+      datasets: [{
+        label: 'Amount',
+        data: @json($transactions->pluck('amount')),
+        backgroundColor: '#4f46e5'
+      }]
+    },
+    options: {
+      plugins: { legend: { display: false } },
+      scales: {
+        y: { beginAtZero: true }
       }
-    });
+    }
+  });
+  document.getElementById('transactionsChartWrapper').__x.$data.loading = false;
   </script>
   <script>
     document.addEventListener('alpine:init', () => {


### PR DESCRIPTION
## Summary
- add CSS spinner animation
- overlay loader on dashboard and transactions charts
- hide loader when charts finish rendering

## Testing
- `npm run build`
- `composer test` *(fails: MissingAppKeyException)*

------
https://chatgpt.com/codex/tasks/task_e_68c4574b33dc832fa0fd29e56c19ef16