### PR TITLE
refactor: use blade components in transaction forms

### DIFF
--- a/resources/views/transactions/create.blade.php
+++ b/resources/views/transactions/create.blade.php
@@ -10,32 +10,37 @@
       <form method="POST" action="{{ route('transactions.store') }}" class="space-y-4">
         @csrf
         <div>
-          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Account</label>
-          <select name="account_id" class="mt-1 block w-full">
+          <x-input-label for="account_id" :value="__('Account')" />
+          <select id="account_id" name="account_id" class="mt-1 block w-full" required>
             @foreach($accounts as $account)
-              <option value="{{ $account->id }}">{{ $account->name }}</option>
+              <option value="{{ $account->id }}" @selected(old('account_id') == $account->id)>{{ $account->name }}</option>
             @endforeach
           </select>
+          <x-input-error :messages="$errors->get('account_id')" class="mt-2" />
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Type</label>
-          <select name="type" class="mt-1 block w-full">
+          <x-input-label for="type" :value="__('Type')" />
+          <select id="type" name="type" class="mt-1 block w-full" required>
             @foreach($types as $type)
               <option value="{{ $type }}" @selected(old('type') === $type)>{{ ucfirst($type) }}</option>
             @endforeach
           </select>
+          <x-input-error :messages="$errors->get('type')" class="mt-2" />
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Description</label>
-          <input type="text" name="description" class="mt-1 block w-full" />
+          <x-input-label for="description" :value="__('Description')" />
+          <x-text-input id="description" name="description" type="text" class="mt-1 block w-full" :value="old('description')" />
+          <x-input-error :messages="$errors->get('description')" class="mt-2" />
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Amount</label>
-          <input type="number" step="0.01" name="amount" class="mt-1 block w-full" />
+          <x-input-label for="amount" :value="__('Amount')" />
+          <x-text-input id="amount" name="amount" type="number" step="0.01" class="mt-1 block w-full" :value="old('amount')" required />
+          <x-input-error :messages="$errors->get('amount')" class="mt-2" />
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Date</label>
-          <input type="date" name="date" class="mt-1 block w-full" />
+          <x-input-label for="date" :value="__('Date')" />
+          <x-text-input id="date" name="date" type="date" class="mt-1 block w-full" :value="old('date')" required />
+          <x-input-error :messages="$errors->get('date')" class="mt-2" />
         </div>
         <div>
           <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Save</button>

--- a/resources/views/transactions/edit.blade.php
+++ b/resources/views/transactions/edit.blade.php
@@ -11,32 +11,37 @@
         @csrf
         @method('PUT')
         <div>
-          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Account</label>
-          <select name="account_id" class="mt-1 block w-full">
+          <x-input-label for="account_id" :value="__('Account')" />
+          <select id="account_id" name="account_id" class="mt-1 block w-full" required>
             @foreach($accounts as $account)
               <option value="{{ $account->id }}" @selected($account->id == old('account_id', $transaction->account_id))>{{ $account->name }}</option>
             @endforeach
           </select>
+          <x-input-error :messages="$errors->get('account_id')" class="mt-2" />
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Type</label>
-          <select name="type" class="mt-1 block w-full">
+          <x-input-label for="type" :value="__('Type')" />
+          <select id="type" name="type" class="mt-1 block w-full" required>
             @foreach($types as $type)
               <option value="{{ $type }}" @selected(old('type', $transaction->type) === $type)>{{ ucfirst($type) }}</option>
             @endforeach
           </select>
+          <x-input-error :messages="$errors->get('type')" class="mt-2" />
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Description</label>
-          <input type="text" name="description" value="{{ old('description', $transaction->description) }}" class="mt-1 block w-full" />
+          <x-input-label for="description" :value="__('Description')" />
+          <x-text-input id="description" name="description" type="text" class="mt-1 block w-full" :value="old('description', $transaction->description)" />
+          <x-input-error :messages="$errors->get('description')" class="mt-2" />
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Amount</label>
-          <input type="number" step="0.01" name="amount" value="{{ old('amount', $transaction->amount) }}" class="mt-1 block w-full" />
+          <x-input-label for="amount" :value="__('Amount')" />
+          <x-text-input id="amount" name="amount" type="number" step="0.01" class="mt-1 block w-full" :value="old('amount', $transaction->amount)" required />
+          <x-input-error :messages="$errors->get('amount')" class="mt-2" />
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Date</label>
-          <input type="date" name="date" value="{{ old('date', $transaction->date) }}" class="mt-1 block w-full" />
+          <x-input-label for="date" :value="__('Date')" />
+          <x-text-input id="date" name="date" type="date" class="mt-1 block w-full" :value="old('date', $transaction->date)" required />
+          <x-input-error :messages="$errors->get('date')" class="mt-2" />
         </div>
         <div>
           <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Update</button>


### PR DESCRIPTION
## Summary
- switch transaction create and edit forms to Blade input components
- add validation error displays and required attributes

## Testing
- `./vendor/bin/pest`


------
https://chatgpt.com/codex/tasks/task_e_68c457487120832fbf03f725f2b67b94