### PR TITLE
Enforce account ownership for account management actions

### DIFF
--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -58,6 +58,8 @@ class AccountController extends Controller
      */
     public function edit(Account $account)
     {
+        abort_unless($account->user_id === Auth::id(), 403);
+
         return view('accounts.edit', compact('account'));
     }
 
@@ -66,6 +68,8 @@ class AccountController extends Controller
      */
     public function update(StoreAccountRequest $request, Account $account)
     {
+        abort_unless($account->user_id === $request->user()->id, 403);
+
         $account->update($request->validated());
 
         return redirect()->route('accounts.index');
@@ -76,6 +80,8 @@ class AccountController extends Controller
      */
     public function destroy(Account $account)
     {
+        abort_unless($account->user_id === Auth::id(), 403);
+
         $account->delete();
 
         return redirect()->route('accounts.index');

--- a/tests/Feature/AccountAuthorizationTest.php
+++ b/tests/Feature/AccountAuthorizationTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use App\Models\Account;
+use App\Models\User;
+
+test('users cannot view the edit form for accounts they do not own', function () {
+    $owner = User::factory()->create();
+    $otherUser = User::factory()->create();
+
+    $account = Account::create([
+        'user_id' => $owner->id,
+        'name' => 'Owner Checking',
+        'type' => 'checking',
+        'balance' => 100,
+    ]);
+
+    $response = $this
+        ->actingAs($otherUser)
+        ->get(route('accounts.edit', $account));
+
+    $response->assertForbidden();
+});
+
+test('users cannot update accounts they do not own', function () {
+    $owner = User::factory()->create();
+    $otherUser = User::factory()->create();
+
+    $account = Account::create([
+        'user_id' => $owner->id,
+        'name' => 'Owner Savings',
+        'type' => 'savings',
+        'balance' => 250,
+    ]);
+
+    $response = $this
+        ->actingAs($otherUser)
+        ->put(route('accounts.update', $account), [
+            'name' => 'Updated Name',
+            'type' => 'checking',
+            'balance' => 500,
+        ]);
+
+    $response->assertForbidden();
+
+    $account->refresh();
+
+    expect($account->name)->toBe('Owner Savings');
+    expect((float) $account->balance)->toBe(250.0);
+    expect($account->type)->toBe('savings');
+});
+
+test('users cannot delete accounts they do not own', function () {
+    $owner = User::factory()->create();
+    $otherUser = User::factory()->create();
+
+    $account = Account::create([
+        'user_id' => $owner->id,
+        'name' => 'Owner Cash',
+        'type' => 'cash',
+        'balance' => 75,
+    ]);
+
+    $response = $this
+        ->actingAs($otherUser)
+        ->delete(route('accounts.destroy', $account));
+
+    $response->assertForbidden();
+
+    expect(Account::query()->whereKey($account->id)->exists())->toBeTrue();
+});


### PR DESCRIPTION
## Summary
- enforce ownership checks before rendering account edit forms, updating, or deleting accounts
- add feature coverage confirming edit, update, and destroy routes return 403 for foreign accounts

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68d2edd2c25c832f95346b993eda0864