### PR TITLE
Secure Plaid token exchange and webhook handling

### DIFF
--- a/app/Http/Controllers/Api/PlaidController.php
+++ b/app/Http/Controllers/Api/PlaidController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Services\PlaidService;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Crypt;
 
 class PlaidController extends Controller
 {
@@ -12,23 +13,102 @@ class PlaidController extends Controller
     {
     }
 
-    public function linkToken()
+    public function linkToken(Request $request)
     {
-        $token = $this->plaid->createLinkToken();
+        $userId = (int) $request->user()->getKey();
+
+        $token = $this->plaid->createLinkToken($userId);
 
         return response()->json(['link_token' => $token]);
     }
 
+    public function exchange(Request $request)
+    {
+        $validated = $request->validate([
+            'public_token' => ['required', 'string'],
+        ]);
+
+        $exchange = $this->plaid->exchangePublicToken($validated['public_token']);
+
+        $request->user()
+            ->forceFill([
+                'plaid_access_token' => Crypt::encryptString($exchange['access_token']),
+            ])
+            ->save();
+
+        return response()->noContent();
+    }
+
     public function webhook(Request $request)
     {
-        $publicToken = $request->input('public_token');
-        $accessToken = $this->plaid->exchangePublicToken($publicToken);
-        $accounts = $this->plaid->getAccounts($accessToken);
+        $secret = config('plaid.webhook_secret');
 
-        return response()->json([
-            'access_token' => $accessToken,
-            'accounts' => $accounts,
+        if (! is_string($secret) || $secret === '') {
+            return response()->json(['message' => 'Webhook secret not configured.'], 500);
+        }
+
+        $signatureHeader = $request->header('Plaid-Webhook-Signature')
+            ?? $request->header('PLAID-WEBHOOK-SIGNATURE');
+
+        if ($signatureHeader === null || $signatureHeader === '') {
+            return response()->json(['message' => 'Missing Plaid signature header.'], 401);
+        }
+
+        $signatures = $this->parseSignatureHeader($signatureHeader);
+
+        if (! isset($signatures['v1']) || $signatures['v1'] === '') {
+            return response()->json(['message' => 'Missing Plaid signature version.'], 401);
+        }
+
+        $expected = hash_hmac('sha256', $request->getContent(), $secret);
+
+        if (! hash_equals($expected, $signatures['v1'])) {
+            return response()->json(['message' => 'Invalid Plaid signature.'], 403);
+        }
+
+        $payload = $request->validate([
+            'webhook_type' => ['required', 'string'],
+            'webhook_code' => ['required', 'string'],
         ]);
+
+        if (! in_array($payload['webhook_type'], $this->allowedWebhookTypes(), true)) {
+            return response()->json(['message' => 'Unsupported webhook type.'], 400);
+        }
+
+        return response()->noContent();
+    }
+
+    protected function parseSignatureHeader(string $header): array
+    {
+        $parts = array_filter(array_map('trim', explode(',', $header)));
+
+        $signatures = [];
+
+        foreach ($parts as $part) {
+            [$key, $value] = array_pad(explode('=', $part, 2), 2, null);
+
+            if ($key !== null && $value !== null) {
+                $signatures[$key] = $value;
+            }
+        }
+
+        return $signatures;
+    }
+
+    protected function allowedWebhookTypes(): array
+    {
+        return [
+            'TRANSACTIONS',
+            'ITEM',
+            'AUTH',
+            'LIABILITIES',
+            'INVESTMENTS_TRANSACTIONS',
+            'HOLDINGS',
+            'PAYMENT_INITIATION',
+            'TRANSFER',
+            'INCOME',
+            'STATEMENTS',
+        ];
     }
 }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -30,6 +30,7 @@ class User extends Authenticatable
     protected $hidden = [
         'password',
         'remember_token',
+        'plaid_access_token',
     ];
 
     /**

--- a/app/Services/PlaidService.php
+++ b/app/Services/PlaidService.php
@@ -12,9 +12,9 @@ class PlaidService
         protected ?string $secret = null,
         protected ?string $environment = null,
     ) {
-         $this->clientId ??= config('plaid.client_id');
-    $this->secret ??= config('plaid.secret');
-    $this->environment ??= config('plaid.env', 'sandbox');
+        $this->clientId ??= config('plaid.client_id');
+        $this->secret ??= config('plaid.secret');
+        $this->environment ??= config('plaid.env', 'sandbox');
     }
 
     public function createLinkToken(?int $userId = null): string
@@ -40,19 +40,28 @@ class PlaidService
         return $linkToken;
     }
 
-    public function exchangePublicToken(string $publicToken): string
+    /**
+     * Exchange a public token for an access token and associated metadata.
+     *
+     * @return array{access_token: string, item_id: string|null}
+     */
+    public function exchangePublicToken(string $publicToken): array
     {
         $response = $this->plaidRequest('/item/public_token/exchange', [
             'public_token' => $publicToken,
         ]);
 
         $accessToken = $response['access_token'] ?? null;
+        $itemId = $response['item_id'] ?? null;
 
         if (! is_string($accessToken) || $accessToken === '') {
             throw new RuntimeException('Plaid did not return an access token.');
         }
 
-        return $accessToken;
+        return [
+            'access_token' => $accessToken,
+            'item_id' => is_string($itemId) && $itemId !== '' ? $itemId : null,
+        ];
     }
 
     public function getAccounts(string $accessToken): array

--- a/config/plaid.php
+++ b/config/plaid.php
@@ -4,4 +4,5 @@ return [
     'client_id' => env('PLAID_CLIENT_ID'),
     'secret'    => env('PLAID_SECRET'),
     'env'       => env('PLAID_ENV', 'sandbox'),
+    'webhook_secret' => env('PLAID_WEBHOOK_SECRET'),
 ];

--- a/database/migrations/2025_09_01_000000_add_plaid_access_token_to_users_table.php
+++ b/database/migrations/2025_09_01_000000_add_plaid_access_token_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->text('plaid_access_token')->nullable()->after('password');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('plaid_access_token');
+        });
+    }
+};

--- a/docs/plaid.md
+++ b/docs/plaid.md
@@ -10,14 +10,16 @@ Set the following environment variables in your `.env` file:
 PLAID_CLIENT_ID=your-client-id
 PLAID_SECRET=your-secret
 PLAID_ENV=sandbox   # or development, production
+PLAID_WEBHOOK_SECRET=your-webhook-secret
 ```
 
 These values are consumed by `config/plaid.php` and used by the `PlaidService`.
 
 ## Endpoints
 
-- `GET /plaid/link-token` – Create a Link token for the authenticated user.
-- `POST /plaid/webhook` – Receive webhook events from Plaid.
+- `GET /plaid/link-token` – Create a Link token for the authenticated user. Requires `auth:sanctum`.
+- `POST /plaid/exchange` – Exchange a public token for an access token. Requires `auth:sanctum` and persists the token server-side.
+- `POST /plaid/webhook` – Receive webhook events from Plaid. Events are validated against the configured webhook secret and supported webhook types.
 
 ## Services
 

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -99,7 +99,7 @@
                         const handler = Plaid.create({
                             token: linkToken,
                             onSuccess: async (publicToken) => {
-                                await fetch('/api/plaid/webhook', {
+                                await fetch('/api/plaid/exchange', {
                                     method: 'POST',
                                     headers: {
                                         'Content-Type': 'application/json',

--- a/routes/api.php
+++ b/routes/api.php
@@ -10,7 +10,9 @@ Route::middleware('auth:sanctum')->group(function () {
 
     Route::get('/dashboard/monthly-totals', [DashboardController::class, 'monthlyTotals']);
     Route::get('/dashboard/category-totals', [DashboardController::class, 'categoryTotals']);
+
+    Route::get('/plaid/link-token', [PlaidController::class, 'linkToken']);
+    Route::post('/plaid/exchange', [PlaidController::class, 'exchange']);
 });
 
-Route::get('/plaid/link-token', [PlaidController::class, 'linkToken']);
 Route::post('/plaid/webhook', [PlaidController::class, 'webhook']);

--- a/tests/Feature/Api/PlaidTest.php
+++ b/tests/Feature/Api/PlaidTest.php
@@ -1,0 +1,127 @@
+<?php
+
+use App\Models\User;
+use App\Services\PlaidService;
+use Illuminate\Support\Facades\Crypt;
+use Laravel\Sanctum\Sanctum;
+use function Pest\Laravel\mock;
+
+it('requires authentication to create a link token', function () {
+    $this->getJson('/api/plaid/link-token')->assertUnauthorized();
+});
+
+it('returns a link token for authenticated users', function () {
+    $user = User::factory()->create();
+
+    Sanctum::actingAs($user);
+
+    mock(PlaidService::class)
+        ->shouldReceive('createLinkToken')
+        ->once()
+        ->withArgs(fn ($userId) => (int) $userId === $user->id)
+        ->andReturn('link-sandbox-token');
+
+    $this->getJson('/api/plaid/link-token')
+        ->assertOk()
+        ->assertJson(['link_token' => 'link-sandbox-token']);
+});
+
+it('requires authentication to exchange a public token', function () {
+    $this->postJson('/api/plaid/exchange', ['public_token' => 'public-token'])
+        ->assertUnauthorized();
+});
+
+it('stores the Plaid access token during exchange', function () {
+    $user = User::factory()->create();
+
+    Sanctum::actingAs($user);
+
+    mock(PlaidService::class)
+        ->shouldReceive('exchangePublicToken')
+        ->once()
+        ->with('public-token')
+        ->andReturn([
+            'access_token' => 'access-token',
+            'item_id' => 'item-id',
+        ]);
+
+    $this->postJson('/api/plaid/exchange', ['public_token' => 'public-token'])
+        ->assertNoContent();
+
+    $freshUser = $user->fresh();
+
+    expect($freshUser->plaid_access_token)->not->toBeNull();
+    expect(Crypt::decryptString($freshUser->plaid_access_token))->toBe('access-token');
+});
+
+it('rejects webhook payloads without a signature header', function () {
+    config(['plaid.webhook_secret' => 'test-secret']);
+
+    $this->postJson('/api/plaid/webhook', [
+        'webhook_type' => 'TRANSACTIONS',
+        'webhook_code' => 'INITIAL_UPDATE',
+    ])->assertStatus(401);
+});
+
+it('rejects webhook payloads with an invalid signature', function () {
+    config(['plaid.webhook_secret' => 'test-secret']);
+
+    $this->withHeaders(['Plaid-Webhook-Signature' => 'v1=invalid'])
+        ->postJson('/api/plaid/webhook', [
+            'webhook_type' => 'TRANSACTIONS',
+            'webhook_code' => 'INITIAL_UPDATE',
+        ])
+        ->assertStatus(403);
+});
+
+it('rejects webhook payloads with unsupported types', function () {
+    config(['plaid.webhook_secret' => 'test-secret']);
+
+    $payload = [
+        'webhook_type' => 'UNKNOWN',
+        'webhook_code' => 'SOMETHING',
+    ];
+
+    $json = json_encode($payload, JSON_THROW_ON_ERROR);
+    $signature = hash_hmac('sha256', $json, 'test-secret');
+
+    $this->call(
+        'POST',
+        '/api/plaid/webhook',
+        [],
+        [],
+        [],
+        [
+            'CONTENT_TYPE' => 'application/json',
+            'HTTP_ACCEPT' => 'application/json',
+            'HTTP_PLAID_WEBHOOK_SIGNATURE' => "v1={$signature}",
+        ],
+        $json
+    )->assertStatus(400);
+});
+
+it('accepts webhook payloads with valid signatures and supported types', function () {
+    config(['plaid.webhook_secret' => 'test-secret']);
+
+    $payload = [
+        'webhook_type' => 'TRANSACTIONS',
+        'webhook_code' => 'INITIAL_UPDATE',
+    ];
+
+    $json = json_encode($payload, JSON_THROW_ON_ERROR);
+    $signature = hash_hmac('sha256', $json, 'test-secret');
+
+    $this->call(
+        'POST',
+        '/api/plaid/webhook',
+        [],
+        [],
+        [],
+        [
+            'CONTENT_TYPE' => 'application/json',
+            'HTTP_ACCEPT' => 'application/json',
+            'HTTP_PLAID_WEBHOOK_SIGNATURE' => "v1={$signature}",
+        ],
+        $json
+    )->assertNoContent();
+});


### PR DESCRIPTION
## Summary
- require Sanctum authentication for generating Plaid Link tokens and exchange public tokens while persisting the encrypted access token for each user
- add Plaid webhook signature validation plus supported event checks, ensuring unauthorized callers receive 401/403 responses
- document the new Plaid endpoints and webhook secret configuration

## Testing
- ./vendor/bin/pest

------
https://chatgpt.com/codex/tasks/task_e_68d2eded0eec832fab21041f84f80f5f